### PR TITLE
Solve workspace LSP problem

### DIFF
--- a/base.code-workspace
+++ b/base.code-workspace
@@ -1,0 +1,9 @@
+{
+    "folders": [
+        {
+            "name": "rails",
+            "path": ".",
+        },
+    ],
+    "settings": {},
+}


### PR DESCRIPTION
## Problem

After creating and running devcontainer, Ruby LSP does not active "go-to-definition" feature, because devcontainer it's a workspace.

## Solution
https://github.com/Shopify/ruby-lsp/blob/main/vscode/README.md?tab=readme-ov-file#multi-root-workspaces

## Screenshot
![image](https://github.com/user-attachments/assets/4d2bbc6b-fb13-4e1c-b63b-60b013f1e7ab)
